### PR TITLE
Removing zope.app.appsetup as a dependency

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ CHANGES
 3.7.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added a test for the zcml_extraction.
 
 
 3.7.4 (2012-05-14)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,8 @@ CHANGES
 
 - Added a test for the zcml_extraction.
 
+- Remove the zope.app.applicationcontrol dependency.
+
 
 3.7.4 (2012-05-14)
 ------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,7 +7,7 @@ CHANGES
 
 - Added a test for the zcml_extraction.
 
-- Remove the zope.app.applicationcontrol dependency.
+- Remove zope.app.applicationcontrol and zope.app.appsetup dependencies.
 
 
 3.7.4 (2012-05-14)

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,6 @@ setup(name='zope.app.locales',
               ],
           extract=[
               'zope.tal',
-              'zope.app.appsetup',
               ],
           ),
       include_package_data = True,

--- a/src/zope/app/locales/extract.py
+++ b/src/zope/app/locales/extract.py
@@ -483,8 +483,14 @@ def py_strings(dir, domain="zope", exclude=(), verify_domain=False):
 def zcml_strings(dir, domain="zope", site_zcml=None):
     """Retrieve all ZCML messages from `dir` that are in the `domain`.
     """
-    from zope.app.appsetup import config
-    context = config(site_zcml, features=("devmode",), execute=False)
+    from zope.configuration import xmlconfig, config
+
+    # Load server-independent site config
+    context = config.ConfigurationMachine()
+    xmlconfig.registerCommonDirectives(context)
+    context.provideFeature("devmode")
+    context = xmlconfig.file(site_zcml, context=context, execute=False)
+
     return context.i18n_strings.get(domain, {})
 
 def tal_strings(dir,

--- a/src/zope/app/locales/extract.py
+++ b/src/zope/app/locales/extract.py
@@ -484,7 +484,6 @@ def zcml_strings(dir, domain="zope", site_zcml=None):
     """Retrieve all ZCML messages from `dir` that are in the `domain`.
     """
     from zope.app.appsetup import config
-    dirname = os.path.dirname
     context = config(site_zcml, features=("devmode",), execute=False)
     return context.i18n_strings.get(domain, {})
 

--- a/src/zope/app/locales/tests.py
+++ b/src/zope/app/locales/tests.py
@@ -16,6 +16,8 @@ __docformat__ = 'restructuredtext'
 
 import doctest
 import os
+import shutil
+import tempfile
 import unittest
 import zope.app.locales
 import zope.component
@@ -66,6 +68,30 @@ class ZCMLTest(unittest.TestCase):
         self.assertEqual(
             s_count, len(list(gsm.registeredSubscriptionAdapters())))
         self.assertEqual(h_count, len(list(gsm.registeredHandlers())))
+
+    def test_zcml_extraction(self):
+        zcml = """
+            <configure xmlns="http://namespaces.zope.org/zope"
+                       i18n_domain="testdomain">
+              <include package="zope.security" file="meta.zcml" />
+                <permission
+                  id="testpkg.TestPermission"
+                  title="Test Permission"
+                  description="This test permission is defined in ZCML"
+                />
+            </configure>
+        """
+        dirname = tempfile.mkdtemp()
+        fn = os.path.join(dirname, 'configure.zcml')
+        with open(fn, 'wt') as zcmlfile:
+            zcmlfile.write(zcml)
+
+        strings = zope.app.locales.extract.zcml_strings('unused', 'testdomain',
+                                                       site_zcml=fn)
+        self.assertEqual(sorted(strings.keys()),
+                         [u'Test Permission',
+                          u'This test permission is defined in ZCML'])
+        shutil.rmtree(dirname)
 
 
 def doctest_POTEntry_sort_order():


### PR DESCRIPTION
zope.app.appsetup drags in most of the rest of Zope 3,
which is not needed to only extract i18n strings from ZCML,
so I copied in the relevant code (and simplified it).

I don't have any tests for this, because despite the best of my efforts I'm not able to find any ZCML that actually means this function returns any strings. If someone can provide an example of that I would be grateful.

This change is necessary for Python 3 support.