### PR TITLE
Implement custom POT file header template

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,9 @@ CHANGES
 
 - Flake8 the code.
 
-- Add support for Python 3.7, 3.8a4 and PyPy3.
+- Add support for Python 3.7, 3.8b1 and PyPy3.
+
+- Port usage of custom POT file header template here from `z3c.recipe.i18n`.
 
 
 4.0.1 (2018-06-29)

--- a/src/zope/app/locales/extract.py
+++ b/src/zope/app/locales/extract.py
@@ -47,10 +47,10 @@ DEFAULT_CHARSET = 'UTF-8'
 DEFAULT_ENCODING = '8bit'
 _import_chickens = {}, {}, ("*",)  # dead chickens needed by __import__
 
-pot_header = u'''\
+DEFAULT_POT_HEADER = pot_header = u'''\
 ##############################################################################
 #
-# Copyright (c) 2003-2017 Zope Foundation and Contributors.
+# Copyright (c) 2003-2019 Zope Foundation and Contributors.
 # All Rights Reserved.
 #
 # This software is subject to the provisions of the Zope Public License,
@@ -205,9 +205,14 @@ class POTEntry(object):
 class POTMaker(object):
     """This class inserts sets of strings into a POT file."""
 
-    def __init__(self, output_fn, path):
+    def __init__(self, output_fn, path, header_template=None):
         self._output_filename = output_fn
         self.path = path
+        if header_template is not None and os.path.exists(header_template):
+            with open(header_template, "r") as file:
+                self._pot_header = file.read()
+        else:
+            self._pot_header = DEFAULT_POT_HEADER
         self.catalog = {}
 
     def add(self, strings, base_dir=None):
@@ -231,6 +236,7 @@ class POTMaker(object):
         return "Unknown"
 
     def write(self):
+        pot_header = self._pot_header
         with open(self._output_filename, 'wb') as file:
             formatted_header = pot_header % {
                 'time': time.ctime(),

--- a/src/zope/app/locales/extract.py
+++ b/src/zope/app/locales/extract.py
@@ -208,9 +208,14 @@ class POTMaker(object):
     def __init__(self, output_fn, path, header_template=None):
         self._output_filename = output_fn
         self.path = path
-        if header_template is not None and os.path.exists(header_template):
-            with open(header_template, "r") as file:
-                self._pot_header = file.read()
+        if header_template is not None:
+            if os.path.exists(header_template):
+                with open(header_template, "r") as file:
+                    self._pot_header = file.read()
+            else:
+                raise ValueError(
+                    "Path {!r} derived from {!r} does not exist.".format(
+                        os.path.abspath(header_template), header_template))
         else:
             self._pot_header = DEFAULT_POT_HEADER
         self.catalog = {}
@@ -236,9 +241,8 @@ class POTMaker(object):
         return "Unknown"
 
     def write(self):
-        pot_header = self._pot_header
         with open(self._output_filename, 'wb') as file:
-            formatted_header = pot_header % {
+            formatted_header = self._pot_header % {
                 'time': time.ctime(),
                 'version': self._getProductVersion(),
                 'charset': DEFAULT_CHARSET,

--- a/src/zope/app/locales/fixtures/header_template.txt
+++ b/src/zope/app/locales/fixtures/header_template.txt
@@ -1,0 +1,6 @@
+# (probably too) minimal example header template
+"Project-Id-Version: %(version)s\\n"
+"POT-Creation-Date: %(time)s\\n"
+"Content-Type: text/plain; charset=%(charset)s\\n"
+"Content-Transfer-Encoding: %(encoding)s\\n"
+

--- a/src/zope/app/locales/tests.py
+++ b/src/zope/app/locales/tests.py
@@ -193,7 +193,8 @@ def doctest_POTMaker_write():
     r"""Test for POTMaker.write
 
         >>> from zope.app.locales.extract import POTMaker
-        >>> path = 'test.pot'
+        >>> tmpdir = tempfile.mkdtemp(prefix='zope.app.locales-test-')
+        >>> path = os.path.join(tmpdir, 'test.pot')
         >>> pm = POTMaker(path, '')
         >>> pm.add({'msgid1': [('file2.py', 2), ('file1.py', 3)],
         ...         'msgid2': [('file1.py', 5)]})
@@ -201,9 +202,9 @@ def doctest_POTMaker_write():
         >>> make_escapes(0)
         >>> pm.write()
 
-        >>> f = open(path)
-        >>> pot = f.read()
-        >>> print(pot)
+        >>> with open(path) as f:
+        ...     pot = f.read()
+        ...     print(pot)
         ##############################################################################
         #
         # Copyright (c) 2003-2019 Zope Foundation and Contributors.
@@ -240,8 +241,7 @@ def doctest_POTMaker_write():
         <BLANKLINE>
         <BLANKLINE>
 
-        >>> f.close()
-        >>> os.remove(path)
+        >>> shutil.rmtree(tmpdir)
 
     """  # noqa: E501
 
@@ -250,7 +250,8 @@ def doctest_POTMaker_custom_header():
     r"""Test for POTMaker.write
 
         >>> from zope.app.locales.extract import POTMaker
-        >>> path = 'test.pot'
+        >>> tmpdir = tempfile.mkdtemp(prefix='zope.app.locales-test-')
+        >>> path = os.path.join(tmpdir, 'test.pot')
         >>> header_template = os.path.join(
         ...     os.path.dirname(__file__), 'fixtures', 'header_template.txt')
         >>> pm = POTMaker(path, '', header_template)
@@ -259,9 +260,9 @@ def doctest_POTMaker_custom_header():
         >>> make_escapes(0)
         >>> pm.write()
 
-        >>> f = open(path)
-        >>> pot = f.read()
-        >>> print(pot)
+        >>> with open(path) as f:
+        ...     pot = f.read()
+        ...     print(pot)
         # (probably too) minimal example header template
         "Project-Id-Version: Unknown\\n"
         "POT-Creation-Date: ...\n"
@@ -273,10 +274,20 @@ def doctest_POTMaker_custom_header():
         msgstr ""
         <BLANKLINE>
         <BLANKLINE>
-        >>> f.close()
-        >>> os.remove(path)
+        >>> shutil.rmtree(tmpdir)
 
     """
+
+
+def doctest_POTMaker_custom_header_not_existing_file():
+    r"""Test for POTMaker.write
+
+        >>> from zope.app.locales.extract import POTMaker
+        >>> POTMaker('test.pot', '', 'header_template.txt')
+        Traceback (most recent call last):
+        ValueError: Path '/.../zope.app.locales/header_template.txt' derived from 'header_template.txt' does not exist.
+
+    """  # noqa: E501
 
 
 class MainTestMixin(object):

--- a/src/zope/app/locales/tests.py
+++ b/src/zope/app/locales/tests.py
@@ -206,7 +206,7 @@ def doctest_POTMaker_write():
         >>> print(pot)
         ##############################################################################
         #
-        # Copyright (c) 2003-2017 Zope Foundation and Contributors.
+        # Copyright (c) 2003-2019 Zope Foundation and Contributors.
         # All Rights Reserved.
         #
         # This software is subject to the provisions of the Zope Public License,
@@ -244,6 +244,39 @@ def doctest_POTMaker_write():
         >>> os.remove(path)
 
     """  # noqa: E501
+
+
+def doctest_POTMaker_custom_header():
+    r"""Test for POTMaker.write
+
+        >>> from zope.app.locales.extract import POTMaker
+        >>> path = 'test.pot'
+        >>> header_template = os.path.join(
+        ...     os.path.dirname(__file__), 'fixtures', 'header_template.txt')
+        >>> pm = POTMaker(path, '', header_template)
+        >>> pm.add({'msgid2': [('file1.py', 5)]})
+        >>> from zope.app.locales.pygettext import make_escapes
+        >>> make_escapes(0)
+        >>> pm.write()
+
+        >>> f = open(path)
+        >>> pot = f.read()
+        >>> print(pot)
+        # (probably too) minimal example header template
+        "Project-Id-Version: Unknown\\n"
+        "POT-Creation-Date: ...\n"
+        "Content-Type: text/plain; charset=UTF-8\\n"
+        "Content-Transfer-Encoding: 8bit\\n"
+        <BLANKLINE>
+        #: file1.py:5
+        msgid "msgid2"
+        msgstr ""
+        <BLANKLINE>
+        <BLANKLINE>
+        >>> f.close()
+        >>> os.remove(path)
+
+    """
 
 
 class MainTestMixin(object):


### PR DESCRIPTION
This is a port from `z3c.recipe.i18n`.

I think it is of general usage but it is untested and broken on Python 3 in z3c.recipe.i18n.