### PR TITLE
Prevent POT files from collecting duplicate location specifiers over …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ CHANGES
 
 - Add support for Python 3.7, 3.8a4 and PyPy3.
 
+- Prevent POT files from collecting duplicate location specifiers over time.
+
 
 4.0.1 (2018-06-29)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(name='zope.app.locales',
       namespace_packages=['zope', 'zope.app'],
       install_requires=[
           'setuptools',
+          'zope.cachedescriptors',
           'zope.i18nmessageid >= 4.1.0',
           'zope.interface',
       ],

--- a/src/zope/app/locales/extract.py
+++ b/src/zope/app/locales/extract.py
@@ -156,6 +156,14 @@ class POTEntry(object):
     >>> entry.locations
     (('zzz', 123),)
 
+    The cache is cleared on a new entry:
+
+    >>> entry = POTEntry('aaa')
+    >>> entry.addLocationComment('zzz', 123)
+    >>> entry.addLocationComment('yyy', 456)
+    >>> entry.locations
+    (('yyy', 456), ('zzz', 123))
+
     """
 
     def __init__(self, msgid, comments=None):

--- a/src/zope/app/locales/tests.py
+++ b/src/zope/app/locales/tests.py
@@ -148,7 +148,7 @@ def doctest_POTMaker_add():
 
     The locations have been sorted
 
-        >>> pm.catalog['msgid1'].locations
+        >>> sorted(pm.catalog['msgid1'].locations)
         [('file1.py', 3), ('file2.py', 2)]
 
     You can call add multiple times and it will merge the entries
@@ -156,7 +156,7 @@ def doctest_POTMaker_add():
         >>> pm.add({'msgid1': [('file1.zcml', 4)],
         ...         'msgid3': [('file2.zcml', 5)]})
 
-        >>> pm.catalog['msgid1'].locations
+        >>> sorted(pm.catalog['msgid1'].locations)
         [('file1.py', 3), ('file1.zcml', 4), ('file2.py', 2)]
 
     """
@@ -183,7 +183,7 @@ def doctest_POTMaker_add_strips_basedirs():
         ...                    ('file1.py', 3),
         ...                    ('notbasedir/file3.py', 5)]},
         ...        'basedir/')
-        >>> pm.catalog['msgid1'].locations
+        >>> sorted(pm.catalog['msgid1'].locations)
         [('file1.py', 3), ('file2.py', 2), ('notbasedir/file3.py', 5)]
 
     """

--- a/src/zope/app/locales/tests.py
+++ b/src/zope/app/locales/tests.py
@@ -148,16 +148,16 @@ def doctest_POTMaker_add():
 
     The locations have been sorted
 
-        >>> sorted(pm.catalog['msgid1'].locations)
-        [('file1.py', 3), ('file2.py', 2)]
+        >>> pm.catalog['msgid1'].locations
+        (('file1.py', 3), ('file2.py', 2))
 
     You can call add multiple times and it will merge the entries
 
         >>> pm.add({'msgid1': [('file1.zcml', 4)],
         ...         'msgid3': [('file2.zcml', 5)]})
 
-        >>> sorted(pm.catalog['msgid1'].locations)
-        [('file1.py', 3), ('file1.zcml', 4), ('file2.py', 2)]
+        >>> pm.catalog['msgid1'].locations
+        (('file1.py', 3), ('file1.zcml', 4), ('file2.py', 2))
 
     """
 
@@ -183,8 +183,8 @@ def doctest_POTMaker_add_strips_basedirs():
         ...                    ('file1.py', 3),
         ...                    ('notbasedir/file3.py', 5)]},
         ...        'basedir/')
-        >>> sorted(pm.catalog['msgid1'].locations)
-        [('file1.py', 3), ('file2.py', 2), ('notbasedir/file3.py', 5)]
+        >>> pm.catalog['msgid1'].locations
+        (('file1.py', 3), ('file2.py', 2), ('notbasedir/file3.py', 5))
 
     """
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,5 +21,5 @@ basepython = python3.6
 usedevelop = true
 commands =
     coverage run -m zope.testrunner --test-path=src []
-    coverage report --show-missing --fail-under=89
+    coverage report --show-missing --fail-under=88
 deps = coverage


### PR DESCRIPTION
…time.

It seems that each time the extraction is run another entry is added.

The coverage is lower because I deleted a line which was covered.