### PR TITLE
Make path in ZCML extraction relative.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ CHANGES
 
 - Add support for Python 3.9.
 
+- Make path in ZCML extraction relative.
+
 
 4.1 (2019-06-24)
 ----------------


### PR DESCRIPTION
This changes the entry of a message id in the .pot file from

```
#: /home/user/project/src/package/src/module/configure.zcml:49
msgid "Edit"
msgstr ""
```

to

```
#: module/configure.zcml:49
msgid "Edit"
msgstr ""
```

It allows different users to use extraction without changing the paths.